### PR TITLE
Incremental Filtering for 'Gold' Marts

### DIFF
--- a/dbt/martian_moments/models/marts/camera_travel_correlation.sql
+++ b/dbt/martian_moments/models/marts/camera_travel_correlation.sql
@@ -17,6 +17,9 @@ WITH photo_with_time AS (
         {{ source('MARS_SILVER', 'FACT_PHOTOS') }} fph
     WHERE 
         fph.rover_id = 8
+        {% if is_incremental() %}
+        AND fph.ingestion_date > (SELECT MAX(ingestion_date) FROM {{ this }})
+        {% endif %}
 )
 SELECT
     dro.rover_name AS name,

--- a/dbt/martian_moments/models/marts/camera_travel_correlation.sql
+++ b/dbt/martian_moments/models/marts/camera_travel_correlation.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized='incremental',
     unique_key=['name', 'sol', 'camera_full_name', 'travel_time_start', 'image'],
-    incremental_strategy='merge',
+    incremental_strategy='append',
     cluster_by=['name', 'sol', 'camera_full_name', 'travel_time_start', 'image'],
     tags='aggregate'
 ) }}
@@ -18,7 +18,7 @@ WITH photo_with_time AS (
     WHERE 
         fph.rover_id = 8
         {% if is_incremental() %}
-        AND fph.ingestion_date > (SELECT MAX(ingestion_date) FROM {{ this }})
+            AND fph.fph_ingestion_date > (SELECT MAX(ingestion_date) FROM {{ this }})
         {% endif %}
 )
 SELECT

--- a/dbt/martian_moments/models/marts/camera_travel_correlation.sql
+++ b/dbt/martian_moments/models/marts/camera_travel_correlation.sql
@@ -6,7 +6,14 @@
     tags='aggregate'
 ) }}
 
-WITH photo_with_time AS (
+WITH max_ingestion AS (
+    SELECT 
+        MAX(ingestion_date) AS max_ingestion_date
+    FROM
+        {{ source('MARS_SILVER', 'FACT_PHOTOS') }} fph
+),
+
+photo_with_time AS (
     SELECT
         fph.rover_id,
         fph.sol,
@@ -18,7 +25,7 @@ WITH photo_with_time AS (
     WHERE 
         fph.rover_id = 8
         {% if is_incremental() %}
-            AND fph.fph_ingestion_date > (SELECT MAX(ingestion_date) FROM {{ this }})
+            AND fph.ingestion_date > (SELECT max_ingestion_date FROM max_ingestion)
         {% endif %}
 )
 SELECT

--- a/dbt/martian_moments/models/marts/daily_activity.sql
+++ b/dbt/martian_moments/models/marts/daily_activity.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized='incremental',
     unique_key=['name', 'sol', 'travel_distance'],
-    incremental_strategy='merge',
+    incremental_strategy='append',
     cluster_by=['name', 'sol', 'travel_distance'],
     tags='aggregate'
 ) }}

--- a/dbt/martian_moments/models/marts/daily_activity.sql
+++ b/dbt/martian_moments/models/marts/daily_activity.sql
@@ -6,6 +6,13 @@
     tags='aggregate'
 ) }}
 
+WITH max_ingestion AS (
+    SELECT 
+        MAX(ingestion_date) AS max_ingestion_date
+    FROM
+        {{ source('MARS_SILVER', 'FACT_PATH') }} fpa
+)
+
 SELECT
     dro.rover_name AS name,
     COALESCE(fpa.sol, fph.sol) AS sol,
@@ -23,6 +30,10 @@ LEFT JOIN
     {{ source('MARS_SILVER', 'FACT_PHOTOS') }} fph ON fpa.rover_id = fph.rover_id AND fpa.sol = fph.sol
 LEFT JOIN
     {{ source('MARS_SILVER', 'DIM_CAMERAS') }} dca ON fph.camera_id = dca.camera_id
+{% if is_incremental() %}
+WHERE 
+    fpa.ingestion_date > (SELECT max_ingestion_date FROM max_ingestion)
+{% endif %}
 GROUP BY 
     dro.rover_name, 
     COALESCE(fpa.sol, fph.sol), 

--- a/dbt/martian_moments/models/marts/photo_summary.sql
+++ b/dbt/martian_moments/models/marts/photo_summary.sql
@@ -1,10 +1,17 @@
 {{ config(
     materialized='incremental',
     unique_key=['rover_name', 'earth_date', 'sol'],
-    incremental_strategy='merge',
+    incremental_strategy='append',
     cluster_by=['rover_name', 'earth_date', 'sol'],
     tags='aggregate'
 ) }}
+
+WITH max_ingestion AS (
+    SELECT 
+        MAX(ingestion_date) AS max_ingestion_date
+    FROM
+        {{ source('MARS_SILVER', 'FACT_PHOTOS') }} fph
+)
 
 SELECT 
     dro.rover_name,
@@ -16,6 +23,10 @@ FROM
     {{ source('MARS_SILVER', 'FACT_PHOTOS') }} fph
 JOIN 
     {{ source('MARS_SILVER', 'DIM_ROVERS') }} dro ON fph.rover_id = dro.rover_id
+{% if is_incremental() %}
+WHERE 
+    fph.ingestion_date > (SELECT max_ingestion_date FROM max_ingestion)
+{% endif %}
 GROUP BY 
     dro.rover_name, 
     fph.earth_date, 

--- a/dbt/martian_moments/models/marts/rover_summary.sql
+++ b/dbt/martian_moments/models/marts/rover_summary.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized='incremental',
     unique_key='rover_name',
-    incremental_strategy='merge',
+    incremental_strategy='append',
     cluster_by='rover_name',
     tags='aggregate'
 ) }}

--- a/dbt/martian_moments/models/staging/dim_cameras.sql
+++ b/dbt/martian_moments/models/staging/dim_cameras.sql
@@ -25,7 +25,8 @@ SELECT
             'MARDI')
             THEN 'Entry, Descent, and Landing'
         ELSE 'Other'
-    END AS camera_category
+    END AS camera_category,
+    ingestion_date
 FROM 
     {{ source('MARS_SILVER', 'FLAT_PHOTO_RESPONSE') }}
 GROUP BY
@@ -33,4 +34,5 @@ GROUP BY
     rover_id,
     camera_name,
     camera_full_name,
-    camera_category
+    camera_category,
+    ingestion_date

--- a/dbt/martian_moments/models/staging/dim_coordinate.sql
+++ b/dbt/martian_moments/models/staging/dim_coordinate.sql
@@ -12,7 +12,7 @@ SELECT
     GET(coord.value, 0) AS longitude,
     GET(coord.value, 1) AS latitude,
     GET(coord.value, 2) AS elevation,
-    fcr.ingestion_date
+    fcr.ingestion_date AS ingestion_date
 FROM 
     {{ source('MARS_SILVER', 'FLAT_COORDINATE_RESPONSE') }} fcr
 CROSS JOIN 

--- a/dbt/martian_moments/models/staging/dim_coordinate.sql
+++ b/dbt/martian_moments/models/staging/dim_coordinate.sql
@@ -12,6 +12,7 @@ SELECT
     GET(coord.value, 0) AS longitude,
     GET(coord.value, 1) AS latitude,
     GET(coord.value, 2) AS elevation,
+    fcr.ingestion_date
 FROM 
     {{ source('MARS_SILVER', 'FLAT_COORDINATE_RESPONSE') }} fcr
 CROSS JOIN 

--- a/dbt/martian_moments/models/staging/dim_rovers.sql
+++ b/dbt/martian_moments/models/staging/dim_rovers.sql
@@ -8,7 +8,8 @@ SELECT
     rover_name,
     rover_status,
     launch_date,
-    landing_date
+    landing_date,
+    ingestion_date
 FROM 
     {{ source('MARS_SILVER', 'FLAT_PHOTO_RESPONSE') }}
 GROUP BY
@@ -16,4 +17,5 @@ GROUP BY
     rover_name,
     rover_status,
     launch_date,
-    landing_date
+    landing_date,
+    ingestion_date

--- a/dbt/martian_moments/models/staging/fact_path.sql
+++ b/dbt/martian_moments/models/staging/fact_path.sql
@@ -22,7 +22,7 @@ SELECT
         ELSE 
             'Long Travel'
     END as day_type,
-    fcr.ingestion_date
+    fcr.ingestion_date as ingestion_date
 FROM 
     {{ source('MARS_SILVER', 'FLAT_COORDINATE_RESPONSE') }} fcr
 JOIN 

--- a/dbt/martian_moments/models/staging/fact_path.sql
+++ b/dbt/martian_moments/models/staging/fact_path.sql
@@ -21,7 +21,8 @@ SELECT
             THEN 'Short Travel'
         ELSE 
             'Long Travel'
-    END as day_type
+    END as day_type,
+    fcr.ingestion_date
 FROM 
     {{ source('MARS_SILVER', 'FLAT_COORDINATE_RESPONSE') }} fcr
 JOIN 

--- a/dbt/martian_moments/models/staging/fact_photos.sql
+++ b/dbt/martian_moments/models/staging/fact_photos.sql
@@ -10,6 +10,7 @@ SELECT
     rover_id,
     earth_date,
     img_src,
+    ingestion_date
 FROM 
     {{ source('MARS_SILVER', 'FLAT_PHOTO_RESPONSE') }}
 GROUP BY
@@ -18,4 +19,5 @@ GROUP BY
     sol,
     rover_id,
     earth_date,
-    img_src 
+    img_src,
+    ingestion_date


### PR DESCRIPTION
This pull request updates several dbt models to improve incremental data loading and ensure ingestion dates are tracked throughout the data pipeline. The main changes are: switching the incremental strategy from `merge` to `append` for several marts, filtering incremental loads using the latest `ingestion_date`, and adding `ingestion_date` columns to multiple staging models.

Incremental loading improvements:
* Changed the `incremental_strategy` from `merge` to `append` in the configs for the following marts: `camera_travel_correlation.sql`, `daily_activity.sql`, and `photo_summary.sql`, to simplify incremental data handling. [[1]](diffhunk://#diff-cb528a2cbf83aa3f40fae3161e1049f717c9dff24cbf08e844f781028917eb06L4-R16) [[2]](diffhunk://#diff-b528224bd13a0e770f441c56b4a41dde9722a147069fd5ab23887dad7425af50L4-R15) [[3]](diffhunk://#diff-a43ef7c4927b0da9f1e52030c33fd246760f91c83f8751fe097d2d4a53f332a3L4-R15)
* For incremental runs, added logic to filter new data by only including records with `ingestion_date` greater than the maximum already ingested, in the marts: `camera_travel_correlation.sql`, `daily_activity.sql`, `photo_summary.sql`, and `rover_summary.sql`. [[1]](diffhunk://#diff-cb528a2cbf83aa3f40fae3161e1049f717c9dff24cbf08e844f781028917eb06R27-R29) [[2]](diffhunk://#diff-b528224bd13a0e770f441c56b4a41dde9722a147069fd5ab23887dad7425af50R33-R36) [[3]](diffhunk://#diff-a43ef7c4927b0da9f1e52030c33fd246760f91c83f8751fe097d2d4a53f332a3R26-R29) [[4]](diffhunk://#diff-990a77a80194853c5ce844c487b1c6cbe35329a6bf001f2ec624089ffd90b81fR28-R31) [[5]](diffhunk://#diff-990a77a80194853c5ce844c487b1c6cbe35329a6bf001f2ec624089ffd90b81fR9-R15)

Data lineage and ingestion tracking:
* Added the `ingestion_date` column to the output of several staging models: `dim_cameras.sql`, `dim_rovers.sql`, `dim_coordinate.sql`, `fact_path.sql`, and `fact_photos.sql`, ensuring ingestion timestamps are available for downstream processing and auditing. [[1]](diffhunk://#diff-ecdba321f5da12b09c467e9d1f7ae807e4d0b7011385450f2bd3f209bff76ef3L28-R38) [[2]](diffhunk://#diff-48233c8ff443c3eb0690ef193c92d18e71300551c57c61f469291bd498e321daL11-R21) [[3]](diffhunk://#diff-6690b2cd0bcb38889b3064c6c1e9d119a972855bb00f34150f6556b581c21bc4R15) [[4]](diffhunk://#diff-37740ad8ce6aa9cd37b5ddebdce56d2f6aeaa19108eb2388c2cfdc7c78c68ceaL24-R25) [[5]](diffhunk://#diff-af2a9900731b4dd7a1efa67a7956a8c6a289f16b1e71236b33f6c7e7947366c0R13) [[6]](diffhunk://#diff-af2a9900731b4dd7a1efa67a7956a8c6a289f16b1e71236b33f6c7e7947366c0L21-R23)