### PR TITLE
Final Optimizations of Photo & Travel Correlation Marts

### DIFF
--- a/dbt/martian_moments/models/marts/camera_travel_correlation.sql
+++ b/dbt/martian_moments/models/marts/camera_travel_correlation.sql
@@ -1,8 +1,8 @@
 {{ config(
     materialized='incremental',
-    unique_key=['name', 'sol', 'camera_full_name', 'travel_time_start', 'image'],
+    unique_key=['image_link'],
     incremental_strategy='append',
-    cluster_by=['name', 'sol', 'camera_full_name', 'travel_time_start', 'image'],
+    cluster_by=['rover_name', 'sol_number', 'camera_name'],
     tags='aggregate'
 ) }}
 
@@ -10,31 +10,33 @@ WITH photo_with_time AS (
     SELECT
         fph.rover_id,
         fph.sol,
-        fph.camera_id,
+        fph.camera_name,
         fph.img_src,
-        REGEXP_SUBSTR(fph.img_src, '_([0-9]{10})_', 1, 1, 'e', 1)::BIGINT AS photo_time
+        REGEXP_SUBSTR(fph.img_src, '_([0-9]{10})_', 1, 1, 'e', 1)::BIGINT AS photo_time,
+        fph.ingestion_date
     FROM 
         {{ source('MARS_SILVER', 'FACT_PHOTOS') }} fph
     WHERE 
         fph.rover_id = 8
         {% if is_incremental() %}
-            AND fph.ingestion_date = (SELECT MAX(ingestion_date) FROM {{ source('MARS_SILVER', 'FACT_PHOTOS') }})
+            AND fph.ingestion_date > (SELECT MAX(ingestion_date) FROM {{ this }})
         {% endif %}
 )
 SELECT
-    dro.rover_name AS name,
-    pwt.sol,
-    dca.camera_full_name,
+    dro.rover_name AS rover_name,
+    pwt.sol AS sol_number,
+    dca.camera_name AS camera_name,
     fpa.sclk_start AS travel_time_start,
     fpa.sclk_end AS travel_time_end,
-    pwt.img_src AS image,
-    pwt.photo_time,
-    pwt.photo_time BETWEEN fpa.sclk_start AND fpa.sclk_end AS taken_during_travel
+    pwt.img_src AS image_link,
+    pwt.photo_time AS photo_time,
+    pwt.photo_time BETWEEN fpa.sclk_start AND fpa.sclk_end AS taken_during_travel,
+    pwt.ingestion_date AS ingestion_date
 FROM 
     photo_with_time pwt
 JOIN 
     {{ source('MARS_SILVER', 'DIM_ROVERS') }} dro ON pwt.rover_id = dro.rover_id
 JOIN 
-    {{ source('MARS_SILVER', 'DIM_CAMERAS') }} dca ON pwt.camera_id = dca.camera_id
+    {{ source('MARS_SILVER', 'DIM_CAMERAS') }} dca ON pwt.rover_id = dca.rover_id AND pwt.camera_name = dca.camera_name
 INNER JOIN 
     {{ source('MARS_SILVER', 'FACT_PATH') }} fpa ON pwt.rover_id = fpa.rover_id AND pwt.sol = fpa.sol

--- a/dbt/martian_moments/models/marts/daily_activity.sql
+++ b/dbt/martian_moments/models/marts/daily_activity.sql
@@ -1,31 +1,32 @@
 {{ config(
     materialized='incremental',
-    unique_key=['name', 'sol', 'travel_distance'],
+    unique_key=['rover_name', 'sol_number', 'travel_distance'],
     incremental_strategy='append',
-    cluster_by=['name', 'sol', 'travel_distance'],
+    cluster_by=['rover_name', 'sol_number', 'travel_distance'],
     tags='aggregate'
 ) }}
 
 SELECT
-    dro.rover_name AS 'Rover Name',
-    fph.sol AS 'Sol Number',
-    fpa.day_type AS 'Day Type',
-    fpa.length AS 'Travel Distance',
-    SUM(CASE WHEN dca.camera_category = 'Engineering' THEN 1 ELSE 0 END) AS 'Engineering Photo Count',
-    SUM(CASE WHEN dca.camera_category = 'Science' THEN 1 ELSE 0 END) AS 'Science Photo Count',
-    SUM(CASE WHEN dca.camera_category = 'Entry, Descent, and Landing' THEN 1 ELSE 0 END) AS 'Entry, Descent, or Landing Photo Count',
-    fph.ingestion_date AS ingestion_date
+    dro.rover_name AS rover_name,
+    fph.sol AS sol_number,
+    COALESCE(fpa.day_type, 'Stationary') AS day_type,
+    COALESCE(fpa.length, 0) AS travel_distance,
+    SUM(CASE WHEN dca.camera_category = 'Engineering' THEN 1 ELSE 0 END) AS engineering_photo_count,
+    SUM(CASE WHEN dca.camera_category = 'Science' THEN 1 ELSE 0 END) AS science_photo_count,
+    SUM(CASE WHEN dca.camera_category = 'Entry, Descent, and Landing' THEN 1 ELSE 0 END) AS edl_photo_count,
+    MAX(fph.ingestion_date) AS ingestion_date
 FROM 
     {{ source('MARS_SILVER', 'FACT_PHOTOS') }} fph
-JOIN
-    {{ source ('MARS_SILVER', 'DIM_ROVERS') }} dro ON fpa.rover_id = dro.rover_id
-JOIN
-    {{ source('MARS_SILVER', 'DIM_CAMERAS') }} dca ON fph.camera_id = dca.camera_id
+LEFT JOIN
+    {{ source('MARS_SILVER', 'DIM_ROVERS') }} dro ON fph.rover_id = dro.rover_id
+LEFT JOIN
+    {{ source('MARS_SILVER', 'DIM_CAMERAS') }} dca ON fph.rover_id = dca.rover_id AND fph.camera_name = dca.camera_name
 LEFT JOIN
     {{ source('MARS_SILVER', 'FACT_PATH') }} fpa ON fph.rover_id = fpa.rover_id AND fph.sol = fpa.sol
+WHERE
+    fph.rover_id = 8
 {% if is_incremental() %}
-WHERE 
-    fpa.ingestion_date = (SELECT MAX(ingestion_date) FROM {{ this }})
+    AND fph.ingestion_date > (SELECT MAX(ingestion_date) FROM {{ this }})
 {% endif %}
 GROUP BY 
     dro.rover_name, 

--- a/dbt/martian_moments/models/staging/fact_path.sql
+++ b/dbt/martian_moments/models/staging/fact_path.sql
@@ -19,7 +19,7 @@ SELECT
     sclk_end,
     CASE 
         WHEN length IS NULL OR length = 0 
-            THEN 'Stationary Day'
+            THEN 'Stationary'
         WHEN length < 5 
             THEN 'Minimal Movement'
         WHEN length < 20 

--- a/dbt/martian_moments/models/staging/fact_photos.sql
+++ b/dbt/martian_moments/models/staging/fact_photos.sql
@@ -5,7 +5,8 @@
 
 SELECT
     image_id,
-    camera_id,
+    camera_id AS nasa_camera_id,
+    camera_name,
     sol,
     rover_id,
     earth_date,


### PR DESCRIPTION
This pull request updates several dbt models to standardize naming conventions, improve join logic, and optimize incremental loading for Mars rover data. The changes enhance data consistency, schema clarity, and ensure more reliable incremental updates.

**Schema and Naming Standardization**

* Updated column names in `camera_travel_correlation.sql` and `daily_activity.sql` to use standardized identifiers such as `rover_name`, `sol_number`, and `camera_name`, replacing previous inconsistent names. (`[[1]](diffhunk://#diff-cb528a2cbf83aa3f40fae3161e1049f717c9dff24cbf08e844f781028917eb06L3-R40)`, `[[2]](diffhunk://#diff-b528224bd13a0e770f441c56b4a41dde9722a147069fd5ab23887dad7425af50L3-R29)`)
* Renamed `camera_id` to `nasa_camera_id` and added `camera_name` in `fact_photos.sql` for clearer schema and future-proofing. (`[dbt/martian_moments/models/staging/fact_photos.sqlL8-R9](diffhunk://#diff-af2a9900731b4dd7a1efa67a7956a8c6a289f16b1e71236b33f6c7e7947366c0L8-R9)`)
* Changed day type label from `'Stationary Day'` to `'Stationary'` in `fact_path.sql` for consistency across models. (`[dbt/martian_moments/models/staging/fact_path.sqlL22-R22](diffhunk://#diff-37740ad8ce6aa9cd37b5ddebdce56d2f6aeaa19108eb2388c2cfdc7c78c68ceaL22-R22)`)

**Join Logic Improvements**

* Modified joins in `camera_travel_correlation.sql` and `daily_activity.sql` to match on `rover_id` and `camera_name` instead of `camera_id`, improving data accuracy and compatibility with updated schemas. (`[[1]](diffhunk://#diff-cb528a2cbf83aa3f40fae3161e1049f717c9dff24cbf08e844f781028917eb06L3-R40)`, `[[2]](diffhunk://#diff-b528224bd13a0e770f441c56b4a41dde9722a147069fd5ab23887dad7425af50L3-R29)`)
* Changed joins from `JOIN` to `LEFT JOIN` in `daily_activity.sql` to ensure all relevant photo records are included, even if camera or rover data is missing. (`[dbt/martian_moments/models/marts/daily_activity.sqlL3-R29](diffhunk://#diff-b528224bd13a0e770f441c56b4a41dde9722a147069fd5ab23887dad7425af50L3-R29)`)

**Incremental Loading and Uniqueness**

* Updated incremental loading logic to only load new records by comparing `ingestion_date` with the maximum in the target table, ensuring efficient and correct data updates. (`[[1]](diffhunk://#diff-cb528a2cbf83aa3f40fae3161e1049f717c9dff24cbf08e844f781028917eb06L3-R40)`, `[[2]](diffhunk://#diff-b528224bd13a0e770f441c56b4a41dde9722a147069fd5ab23887dad7425af50L3-R29)`)
* Changed `unique_key` and `cluster_by` configurations to use standardized columns, improving table indexing and query performance. (`[[1]](diffhunk://#diff-cb528a2cbf83aa3f40fae3161e1049f717c9dff24cbf08e844f781028917eb06L3-R40)`, `[[2]](diffhunk://#diff-b528224bd13a0e770f441c56b4a41dde9722a147069fd5ab23887dad7425af50L3-R29)`)

**Aggregate and Calculation Enhancements**

* Improved photo count aggregations in `daily_activity.sql` with standardized column names and calculation logic, including use of `MAX(ingestion_date)` for better incremental tracking. (`[dbt/martian_moments/models/marts/daily_activity.sqlL3-R29](diffhunk://#diff-b528224bd13a0e770f441c56b4a41dde9722a147069fd5ab23887dad7425af50L3-R29)`)
* Added `ingestion_date` to output columns in both marts for better traceability of data freshness. (`[[1]](diffhunk://#diff-cb528a2cbf83aa3f40fae3161e1049f717c9dff24cbf08e844f781028917eb06L3-R40)`, `[[2]](diffhunk://#diff-b528224bd13a0e770f441c56b4a41dde9722a147069fd5ab23887dad7425af50L3-R29)`)